### PR TITLE
Don't fail if the wiki is disabled

### DIFF
--- a/api/projects/projects.go
+++ b/api/projects/projects.go
@@ -121,7 +121,7 @@ func GetProjectWikis(project *gitlab.Project, client *gitlab.Client) []*gitlab.W
 	}
 	p, response, err := client.Wikis.ListWikis(project.ID, opt)
 	if err != nil {
-		log.Fatalf("Failed to list wikis: %v %v", response, err)
+		log.Printf("Failed to list wikis: %v %v", response, err)
 	}
 	wikis = append(wikis, p...)
 


### PR DESCRIPTION
This change fixes #12. This could be prettier. Here is the output...
```
$ ./gh-gitlab-stats --token $GITLAB_API_PRIVATE_TOKEN --output-file gl-stats.csv --hostname $GITLAB_HOST
 ▀ Fetching Groups (0s)Found group mindfulrob
 SUCCESS  Groups fetched successfully                    
 SUCCESS  Projects fetched successfully                  
 ▄ Fetching mindfulrob/superbigmonorepo MetaData (0s)2023/10/26 14:28:21 Failed to list wikis: &{0x1400029a7e0 0 0 0 0 0 0} GET https://gitlab-td-robandpdx.expert-services.io/api/v4/projects/1/wikis: 403 {message: 403 Forbidden}
 SUCCESS  mindfulrob/superbigmonorepo MetaData fetched successfully
 SUCCESS  CSV File created successfully
```

@pmartindev @amenocal