### PR TITLE
add ability to pass a list of groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,16 @@ GitLab-Stats is a command-line interface that gathers GitLab metrics from a spec
 | `hostname` | The hostname of the GitLab instance to gather metrics from. E.g `https://gitlab.company.com` | Yes | N/A |
 | `token` | The token to use to authenticate to the GitLab instance. | Yes | N/A |
 | `output-file` | The output file name to write the results to. | No | `gitlab-stats-YYYY-MM-DD-HH-MM-SS.csv` |
+| `groups` | A comma-separated list of groups to gather metrics from. | No | "" |
 
 ## How to Run
 
 1. `gh extension install mona-actions/gh-gitlab-stats`
 2. Run the tool: `gh gitlab-stats --hostname <hostname> --token <token> --output-file <filename>`
+
+## Upgrade
+
+`gh extension upgrade gitlab-stats`
 
 ## Usage
 
@@ -33,10 +38,11 @@ Usage:
   gh gitlab-stats [flags]
 
 Flags:
-  -s, --hostname string   The hostname of the GitLab instance to gather metrics from E.g https://gitlab.company.com
-  -h, --help                     help for gh-gitlab-stats
-  -f, --output-file string       The output file name to write the results to (default "gitlab-stats-YYYY-MM-DD-HH-MM-SS.csv")
-  -t, --token string             The token to use to authenticate to the GitLab instance
+  -g, --groups string        The specific groups to gather metrics from. E.g group1,group2,group3
+  -h, --help                 help for gh
+  -s, --hostname string      The hostname/server of the GitLab instance to gather metrics from E.g https://gitlab.company.com
+  -f, --output-file string   The output file name to write the results to (default "gitlab-stats-YYYY-MM-DD-HH-MM-SS.csv")
+  -t, --token string         The token to use to authenticate to the GitLab instance
 ```
 
 ## Permissions

--- a/api/groups/groups.go
+++ b/api/groups/groups.go
@@ -36,3 +36,47 @@ func GetGroups(client *gitlab.Client) []*gitlab.Group {
 
 	return groups
 }
+
+func GetGroupsByName(client *gitlab.Client, groupName string) []*gitlab.Group {
+	opt := &gitlab.ListGroupsOptions{
+		ListOptions: gitlab.ListOptions{
+			PerPage: 100,
+			Page:    1,
+		},
+		Search: &groupName,
+	}
+	group, _, err := client.Groups.ListGroups(opt)
+	if err != nil {
+		log.Printf("Failed to list groups: %v", err)
+		return nil
+	}
+	return group
+}
+
+func GetGroupsProjects(client *gitlab.Client, groups []*gitlab.Group) []*gitlab.Project {
+	var projects []*gitlab.Project
+	for _, group := range groups {
+		opt := &gitlab.ListGroupProjectsOptions{
+			ListOptions: gitlab.ListOptions{
+				PerPage: 100,
+				Page:    1,
+			},
+		}
+		for {
+			p, response, err := client.Groups.ListGroupProjects(group.ID, opt)
+
+			if err != nil {
+				log.Printf("Failed to list projects: %v", err)
+			}
+			projects = append(projects, p...)
+
+			if response.NextPage == 0 {
+				break
+			}
+
+			opt.Page = response.NextPage
+		}
+	}
+
+	return projects
+}

--- a/api/projects/projects.go
+++ b/api/projects/projects.go
@@ -35,6 +35,17 @@ func GetProjects(client *gitlab.Client) []*gitlab.Project {
 	return projects
 }
 
+func GetProject(project *gitlab.Project, client *gitlab.Client) *gitlab.Project {
+	opt := &gitlab.GetProjectOptions{
+		Statistics: gitlab.Bool(true),
+	}
+	project, _, err := client.Projects.GetProject(project.ID, opt)
+	if err != nil {
+		log.Printf("Failed to get project:%v %v", project.Name, err)
+	}
+	return project
+}
+
 func GetProjectMilestones(project *gitlab.Project, client *gitlab.Client) []*gitlab.Milestone {
 	var milestones []*gitlab.Milestone
 	opt := &gitlab.ListMilestonesOptions{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,25 +62,38 @@ func init() {
 	rootCmd.MarkFlagRequired("token")
 
 	rootCmd.Flags().StringP("output-file", "f", "gitlab-stats-"+timestamp+".csv", "The output file name to write the results to")
+
+	rootCmd.Flags().StringP("groups", "g", "", "The specific groups to gather metrics from. E.g group1,group2,group3")
 }
 
 func getGitlabStats(cmd *cobra.Command, args []string) {
-
+	// Init Variables
 	gitlabHostname := cmd.Flag("hostname").Value.String()
+	groupNames := cmd.Flag("groups").Value.String()
+	gitlabToken := cmd.Flag("token").Value.String()
+	outputFileName := cmd.Flag("output-file").Value.String()
+	var gitlabGroups []*gitlab.Group
+	var gitlabProjects []*gitlab.Project
 	checkVars(cmd)
 	if !strings.HasPrefix(gitlabHostname, "http://") && !strings.HasPrefix(gitlabHostname, "https://") {
 		gitlabHostname = "https://" + gitlabHostname
 	}
-	gitlabToken := cmd.Flag("token").Value.String()
-	outputFileName := cmd.Flag("output-file").Value.String()
+
+	//Init GitLab Client
 	client := initClient(gitlabHostname, gitlabToken)
-	//getNamespaces(client)
-	groupSpinnerSuccess, _ := pterm.DefaultSpinner.Start("Fetching Groups")
-	groups.GetGroups(client)
-	groupSpinnerSuccess.Success("Groups fetched successfully")
+
+	if groupNames != "" {
+		groupSpinnerSuccess, _ := pterm.DefaultSpinner.Start("Fetching Groups")
+		gitlabGroups = internal.GetGroupsFromNames(client, groupNames)
+		groupSpinnerSuccess.Success("Groups fetched successfully")
+	}
 
 	projectSpinnerSuccess, _ := pterm.DefaultSpinner.Start("Fetching Projects")
-	gitlabProjects := projects.GetProjects(client)
+	if groupNames != "" {
+		gitlabProjects = GetGitLabGroupsProjects(client, gitlabGroups)
+	} else {
+		gitlabProjects = projects.GetProjects(client)
+	}
 	projectSpinnerSuccess.Success("Projects fetched successfully")
 
 	gitlabProjectsSummary := internal.GetProjectSummary(gitlabProjects, client)
@@ -117,4 +130,18 @@ func checkVars(cmd *cobra.Command) {
 	} else if gitlabHostname == "" {
 		log.Fatalf("The hostname cannot be empty")
 	}
+}
+
+func GetGitLabGroupsProjects(client *gitlab.Client, gitlabGroups []*gitlab.Group) []*gitlab.Project {
+	var gitlabProjects []*gitlab.Project
+
+	// Get all projects in the specified groups
+	groupsProjects := groups.GetGroupsProjects(client, gitlabGroups)
+	for _, project := range groupsProjects {
+
+		// Get the project details with statistics
+		gitlabProject := projects.GetProject(project, client)
+		gitlabProjects = append(gitlabProjects, gitlabProject)
+	}
+	return gitlabProjects
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,10 @@ func getGitlabStats(cmd *cobra.Command, args []string) {
 	if groupNames != "" {
 		groupSpinnerSuccess, _ := pterm.DefaultSpinner.Start("Fetching Groups")
 		gitlabGroups = internal.GetGroupsFromNames(client, groupNames)
+		if len(gitlabGroups) == 0 {
+			groupSpinnerSuccess.Info("No groups found")
+			os.Exit(0)
+		}
 		groupSpinnerSuccess.Success("Groups fetched successfully")
 	}
 

--- a/internal/groups.go
+++ b/internal/groups.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"log"
+	"strings"
+
+	"github.com/mona-actions/gh-gitlab-stats/api/groups"
+	"github.com/xanzy/go-gitlab"
+)
+
+func GetGroupsFromNames(client *gitlab.Client, groupNames string) []*gitlab.Group {
+	var gitlabGroups []*gitlab.Group
+	groupNames = strings.ReplaceAll(groupNames, " ", "")
+
+	groupNamesSlice := strings.Split(groupNames, ",")
+	for _, groupName := range groupNamesSlice {
+		group := groups.GetGroupsByName(client, groupName)
+		if group == nil {
+			log.Printf("Group %s not found", groupName)
+		}
+		gitlabGroups = append(gitlabGroups, group...)
+	}
+	return gitlabGroups
+}

--- a/internal/projectSummary.go
+++ b/internal/projectSummary.go
@@ -65,7 +65,7 @@ func GetProjectSummary(gitlabProjects []*gitlab.Project, client *gitlab.Client) 
 			commitCommentCount += len(commitComments)
 		}
 
-		if projectCommits != nil {
+		if len(projectCommits) > 0 {
 			lastCommit := projectCommits[0]
 			lastPush = lastCommit.CommittedDate
 			//fmt.Println(lastCommit.CommittedDate, lastCommit.Title)
@@ -100,6 +100,10 @@ func GetProjectSummary(gitlabProjects []*gitlab.Project, client *gitlab.Client) 
 		}
 
 		projectReleases := projects.GetProjectReleases(project, client)
+
+		if project.TagList == nil {
+			project.TagList = []string{}
+		}
 
 		recordCount := len(projectCommits) + len(projectIssues) + len(mergeRequests) + len(projectMilestones) + len(projectReleases) + len(projectIssueBoards) + len(projectBranches) + len(project.TagList) + mergeRequestCommentCount + issueCommentCount + commitCommentCount
 		if project != nil && project.Statistics != nil {


### PR DESCRIPTION
would resolve #23 

This pull request mainly focuses on enhancing the GitLab-Stats CLI tool by introducing a new feature that allows users to gather metrics from specific GitLab groups. 

Enhancements to the GitLab-Stats CLI tool:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R29">`README.md`</a>: Updated the instructions on how to run the tool and the usage section to include information about the new `groups` flag. This flag allows users to specify a comma-separated list of groups from which to gather metrics. Also added an upgrade section.

New functions and modifications:

* <a href="diffhunk://#diff-1aaa82ed92c5e17441f55d565ca696cf3882d23fd8ff57429abf608861e618cfR39-R82">`api/groups/groups.go`</a>: Added new functions `GetGroupsByName` and `GetGroupsProjects` to fetch GitLab groups by name and to get projects within these groups respectively.
* <a href="diffhunk://#diff-b16aba3b132b93d25627357212ec4a7c837891d0749c38527fdd6ee19e9caf36R38-R48">`api/projects/projects.go`</a>: Added a new function `GetProject` to fetch a GitLab project along with its statistics.
* <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR65-R96">`cmd/root.go`</a>: Modified the `init` and `getGitlabStats` functions to handle the new `groups` flag and to fetch GitLab groups and projects based on the provided group names. Also added a new function `GetGitLabGroupsProjects` to fetch projects from the specified groups. <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR65-R96">[1]</a> <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR134-R147">[2]</a>

New file:

* <a href="diffhunk://#diff-22756e8699c65bc496fa0498c1746364c19f6e5f9ad916022deedc689b00aae6R1-R24">`internal/groups.go`</a>: Created a new file containing the `GetGroupsFromNames` function which fetches GitLab groups based on the provided group names.