### PR TITLE
Update release workflow for gh-extension-precompile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 #v4.1.0
-      - uses: cli/gh-extension-precompile@640911b0a0f2adb89a07a8ba547053cbd4001e1e #v1.3.1
+      - uses: cli/gh-extension-precompile@561b19deda1228a0edf856c3325df87416f8c9bd #v2.0.0
         with:
-          go_version: "1.21"
+          go_version_file: go.mod


### PR DESCRIPTION
Updated GitHub Actions workflow to use new version of gh-extension-precompile and changed go_version to go_version_file.

Key changes in `.github/workflows/release.yml`:

* Updated the `gh-extension-precompile` action from version `v1.3.1` to `v2.0.0`, which likely includes improvements or fixes.
* Replaced the explicit `go_version: "1.21"` with `go_version_file: go.mod`, allowing the Go version to be determined directly from the `go.mod` file for better maintainability.